### PR TITLE
adding laravel8 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^7.0"
+        "laravel/framework": "^7.0|^8.0"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Why:

Not works on laravel8 projects because it requires only laravel ^7.0.

Changes: 

Tested on a laravel 8 project, and it works on laravel8 too so I added laravel8 support.